### PR TITLE
Point out that in the W3C, errata fixes are never new features.

### DIFF
--- a/rdf-star-council-report.bs
+++ b/rdf-star-council-report.bs
@@ -143,6 +143,11 @@ system](https://www.w3.org/2002/09/wbs/). The [W3C
 Council](https://www.w3.org/policies/process/#council) process is able to make better decisions if
 formal objections are about more specific decisions.
 
+Not everyone in the W3C community is aware that the Process gives a precise definition for "errata",
+so we recommend that the charter be editorially changed to link the use in the [scope
+section](https://www.w3.org/2024/10/proposed-rdf-star-wg-charter.html#scope) to its [definition in
+the Process](https://www.w3.org/policies/process/#errata).
+
 We also encourage the objector and the WG chairs to work together to find a mutually agreeable
 schedule to accomplish the group's chartered work.
 

--- a/rdf-star-council-report.bs
+++ b/rdf-star-council-report.bs
@@ -124,10 +124,15 @@ reading of this part of the Process.
 
 The objector argues that "addressing" an erratum by adding a targeted feature could produce a worse
 final language than could be achieved by considering the whole space of feature requests and fixing
-them with coherent language changes. This is correct. However, the charter does not require the
-Working Group to make this mistake. Not all missing features are errata, and a serious erratum that
-highlights a desirable feature can be addressed by documenting a plan to recharter and add the
-feature in a coherent document revision.
+them with coherent language changes. This is correct. However, the W3C Process defines an
+[erratum](https://www.w3.org/policies/process/#errata) as
+
+> any error that can be resolved by one or more changes in [classes 1-3 of section §6.2.3 Classes of
+> Changes](https://www.w3.org/policies/process/#correction-classes).
+
+That is, the revised charter does not allow the Working Group to add features in order to fix
+errors. Errors that can only be fixed by the addition of new features will require the group to
+recharter, at which point a coherent set of features can be added.
 
 <h2 id="recommendations">Recommendations</h2>
 


### PR DESCRIPTION
Applies part of @fantasai's suggestion from https://lists.w3.org/Archives/Group/group-council-2025-01-rdfstar/2025Mar/0002.html.

I hadn't realized that https://www.w3.org/policies/process/#errata defines "erratum" to exclude anything that needs a new feature to fix, so I think this is the right place to put this correction, but I'm also happy to hear other suggestions. 