### PR TITLE
link editorial: drop comma, more descriptive linktext

### DIFF
--- a/rdf-star-council-report.bs
+++ b/rdf-star-council-report.bs
@@ -31,7 +31,7 @@ href="https://github.com/jyasskin/draft-council-reports/blob/main/rdf-star-counc
 <h2 id="intro">Introduction</h2>
 
 A detailed exposition of this case may be found in the
-[report](https://www.w3.org/2024/11/team-report-rdf-star-wg-charter.html), prepared by the W3C Team,
+[report prepared by the W3C Team](https://www.w3.org/2024/11/team-report-rdf-star-wg-charter.html),
 and the [elaboration on the objection, by the
 objector](https://www.w3.org/2024/11/rdf-star-objection.pdf).
 


### PR DESCRIPTION
the comma after report is unnecessary as "report by ..." makes sense there. 

also, it makes sense to include "report ... team" as the full linktext similar to the longer linktext for the objector's PDF.