### PR TITLE
Mention that the charter could be improved by removing a "the".

### DIFF
--- a/rdf-star-council-report.bs
+++ b/rdf-star-council-report.bs
@@ -179,6 +179,11 @@ schedule to accomplish the group's chartered work.
 	Syntax](https://www.w3.org/2024/10/proposed-rdf-star-wg-charter.html#rdf-syntax-grammar)
 	deliverable still mentions just &ldquo;editorial errata&rdquo;. It would be best to align that
 	with the rest of the charter, but this is again not part of resolving this formal objection.
+* The updated charter includes a statement that "the pending errata will also be addressed". This
+	implies that _all_ pending errata will be addressed, and in conversation with some members of
+	the Working Group, the council discovered that their intent was only to commit to addressing
+	_some_ of the pending errata. Removing "the" would improve the alignment between the charter and
+	the WG's intent, but the objector has indicated that it would not resolve their objection.
 
 <h2 id="participation" class=no-num>Appendix A: Council Participation</h2>
 


### PR DESCRIPTION
"the pending errata will also be addressed" -> just "pending errata will
also be addressed", indicating that maybe not all the errata will be
addressed during the life of the charter.


How does this look, @fantasai & @martinthomson? Do we need to explicitly say here that removing "the" is a "substantive change" that will trigger the "consensus of the subset" process in https://www.w3.org/policies/process/#ACReviewAfter? I'm inclined to think we don't need to say it.

@ylafon and @pchampin, do you need anything more than this to fix this bit of the charter?